### PR TITLE
added dynamic headers for each month

### DIFF
--- a/EV.moveVis.R
+++ b/EV.moveVis.R
@@ -126,6 +126,14 @@ frames <- add_labels(frames, x = "Longitude", y = "Latitude")
 frames <- add_progress(frames, size = 2) # add a progress bar
 frames[[300]]
 
+### create monthly labels
+## the default function 'add_labels' is not temporally dynamic!
+monthlabel<-month.name[month(unique(move_data@data$time))]
+
+for (f in 1: length(frames)){
+  frames[[f]]$labels$title <- sprintf("Egyptian Vulture migration in %s",monthlabel[f])
+}
+
 # animate frame
 suggest_formats()
 animate_frames(frames, out_file = "./Outputs/EgyptianVulture_MovementAnimation_MigrationFlexibility_Satellite.mp4", overwrite = TRUE,


### PR DESCRIPTION
changed the slot for header in each frame manually as the 'add_labels' function does not differentiate between frames and therefore does not work.

This should provide a more intuitive time scale at the top of the plot.